### PR TITLE
Make each message serializable by annotated with @Message (Java)

### DIFF
--- a/msgpack-idl/Language/MessagePack/IDL/CodeGen/Java.hs
+++ b/msgpack-idl/Language/MessagePack/IDL/CodeGen/Java.hs
@@ -70,7 +70,10 @@ package #{packageName};
 
 #{hashMapImport}
 #{arrayListImport}
+import org.msgpack.MessagePack;
+import org.msgpack.annotation.Message;
 
+@Message
 public class #{formatClassNameT msgName} #{params} {
 
 #{LT.concat $ map genDecl resolvedMsgFields}
@@ -120,8 +123,11 @@ genException packageName MPException {..} = do
   LT.writeFile ( (formatClassName $ T.unpack excName) ++ ".java") [lt|
 package #{packageName};
 
-public class #{formatClassNameT excName} #{params}{
+import org.msgpack.MessagePack;
+import org.msgpack.annotation.Message;
 
+@Message
+public class #{formatClassNameT excName} #{params}{
 #{LT.concat $ map genDecl excFields}
   public #{formatClassNameT excName}() {
   #{LT.concat $ map genInit excFields}


### PR DESCRIPTION
Each message in .idl file is realized as class in Java Client. These classes was not serializable in current generated code. So we should annotate them by @Message so that it is serializable.
