### PR TITLE
Java Client(Alias Fix and File Path Fix)

### DIFF
--- a/msgpack-idl/Language/MessagePack/IDL/CodeGen/Java.hs
+++ b/msgpack-idl/Language/MessagePack/IDL/CodeGen/Java.hs
@@ -58,6 +58,10 @@ genAliasClass Config{..} alias = do
       fileName =  dirName ++ "/" ++ (T.unpack typeName) ++ ".java"
   LT.writeFile fileName $ templ configFilePath [lt|
 package #{configPackage};
+import org.msgpack.MessagePack;
+import org.msgpack.annotation.Message;
+
+@Message
 public class #{typeName} {
   #{genType actualType} impl;
 };
@@ -99,7 +103,13 @@ genTuple Config{..} (TTuple typeList ) = do
             dirName = joinPath $ map LT.unpack $ LT.split (== '.') $ LT.pack configPackage
             fileName =  dirName ++ "/" ++ className ++ ".java"
         LT.writeFile fileName $ templ configFilePath [lt|
+
 package #{configPackage};
+
+import org.msgpack.MessagePack;
+import org.msgpack.annotation.Message;
+
+@Message
 public class #{className} {
   public #{first} first;
   public #{second} second;


### PR DESCRIPTION
This pull request includes following fixes.
(It contains not only alias fix but also file path fix. I'm sorry for confusing branch name.)
- In former implementation, type alias in idl (e.g. type ids = list<int>) is resolved when generating client code. But this results in disappearing alias name (i.e. ids) in client code. I changed not to resolve alias name. Instead alias name is realized as class (in the previous example, Ids.java will be generated).
- Package name is taken into consideration in paths of generated files. For example, when package name is com.msgpack (which is specified by -p option in mpidl), generated file will be created in <top_dir>/com/msgpack/ directory.
