### PR TITLE
Java tuple fix

### DIFF
--- a/msgpack-idl/Language/MessagePack/IDL/CodeGen/Java.hs
+++ b/msgpack-idl/Language/MessagePack/IDL/CodeGen/Java.hs
@@ -301,7 +301,7 @@ genType (TUserDef className params) =
   [lt|#{formatClassNameT className} #{associateBracket $ map genType params}|]
 genType (TTuple ts) =
   -- TODO: FIX
-  foldr1 (\t1 t2 -> [lt|Tuple<#{t1}, #{t2} >|]) $ map genWrapperType ts
+  foldr1 (\t1 t2 -> [lt|Tuple#{formatClassNameLT t1}#{formatClassNameLT t2}|]) $ map genWrapperType ts
 genType TObject =
   [lt|org.msgpack.type.Value|]
 genType TVoid =
@@ -353,7 +353,7 @@ genWrapperType (TUserDef className params) =
   [lt|#{formatClassNameT className} #{associateBracket $ map genWrapperType params}|]
 genWrapperType (TTuple ts) =
   -- TODO: FIX
-  foldr1 (\t1 t2 -> [lt|Tuple<#{t1}, #{t2} >|]) $ map genWrapperType ts
+  foldr1 (\t1 t2 -> [lt|Tuple#{formatClassNameLT t1}#{formatClassNameLT t2}|]) $ map genWrapperType ts
 genWrapperType TObject =
   [lt|org.msgpack.type.Value|]
 genWrapperType TVoid =


### PR DESCRIPTION
In former implementation, tuple in idl is realized as generic class Tuple<T, U>. But it cannot be deserialized in msgpack type. 
This pull request is patch for this problem.

Instead of creating generic type, concrete class is created for each tuple type appeared in .idl file.
For example, tuple<string, double> is realized as TupleStringDouble class and tuple<tuple<string, double>, double> is TupleTupleStringDoubleDouble. 
(This class name is somewhat lengthy and difficult to read, so if more clever naming is available, I'd like to choose it.)
