### PR TITLE
Added template and Changed type signature of genException in Java

### DIFF
--- a/msgpack-idl/Language/MessagePack/IDL/CodeGen/Cpp.hs
+++ b/msgpack-idl/Language/MessagePack/IDL/CodeGen/Cpp.hs
@@ -64,7 +64,7 @@ generate Config {..} spec = do
 #{genNameSpace (snoc ns "server") $ LT.concat $ map (genServer configPFICommon) spec}
 |]
 
-  LT.writeFile (name ++ "_client.hpp") [lt|
+  LT.writeFile (name ++ "_client.hpp") $ templ configFilePath once "CLIENT" [lt|
 #include "#{name}_types.hpp"
 #{clientHeader}
 

--- a/msgpack-idl/Language/MessagePack/IDL/CodeGen/Ruby.hs
+++ b/msgpack-idl/Language/MessagePack/IDL/CodeGen/Ruby.hs
@@ -31,7 +31,7 @@ generate Config {..} spec = do
   let
         mods = LT.splitOn "::" $ LT.pack configModule
         
-  LT.writeFile "types.rb" $ [lt|
+  LT.writeFile "types.rb" $ templ configFilePath [lt|
 require 'rubygems'
 require 'msgpack/rpc'
 #{genModule mods $ LT.concat $ map (genTypeDecl "") spec }


### PR DESCRIPTION
Some template, which indicating that this client is auto-generated is missing in clients.
This patch is fix of this problem.

This change involves change of type signature of genException because previous signature of genException does not contain path to idl file, which is written on the template.
