### PR TITLE
Remove Upper Bounds

### DIFF
--- a/msgpack/msgpack.cabal
+++ b/msgpack/msgpack.cabal
@@ -21,16 +21,16 @@ Library
   Build-depends:    base          == 4.*
                   , ghc-prim      >= 0.2
                   , mtl           >= 2.0
-                  , bytestring    == 0.9.*
-                  , text          == 0.11.*
+                  , bytestring    >= 0.9
+                  , text          >= 0.11
                   , containers    >= 0.4
-                  , unordered-containers >= 0.1 && < 0.3
+                  , unordered-containers >= 0.1
                   , hashable
-                  , vector        >= 0.7 && < 0.10
-                  , attoparsec    >= 0.8 && < 0.11
-                  , blaze-builder >= 0.3 && < 0.4
-                  , deepseq       >= 1.1 && < 1.4
-                  , template-haskell >= 2.4 && < 2.8
+                  , vector        >= 0.7
+                  , attoparsec    >= 0.8
+                  , blaze-builder >= 0.3
+                  , deepseq       >= 1.1
+                  , template-haskell >= 2.4
 
   Ghc-options:      -Wall
 


### PR DESCRIPTION
Template-haskell, bytestring, and vector all have newer versions that
work fine, but users of these newer versions have headaches when trying
to use msgpack.  This is a great example of why upper-bounds do more
harm than good.
