### PR TITLE
Enable timeout in Java

### DIFF
--- a/msgpack-idl/Language/MessagePack/IDL/CodeGen/Java.hs
+++ b/msgpack-idl/Language/MessagePack/IDL/CodeGen/Java.hs
@@ -172,6 +172,7 @@ public class #{className} {
   public #{className}(String host, int port, double timeout_sec) throws Exception {
     EventLoop loop = EventLoop.defaultEventLoop();
     c_ = new Client(host, port, loop);
+    c_.setRequestTimeout((int) timeout_sec);
     iface_ = c_.proxy(RPCInterface.class);
   }
 


### PR DESCRIPTION
Java client classes have a constructor signature like:

``` java
public MyClient(String host, int port, double timeout_sec) {
```

But `timeout_sec` is currently ignored in generated Java code.

This patch is using `timeout_sec` for request-timeout.
