### PR TITLE
Fixed bugs in Derive.hs

### DIFF
--- a/msgpack/Data/MessagePack/Derive.hs
+++ b/msgpack/Data/MessagePack/Derive.hs
@@ -45,7 +45,7 @@ derivePack asObject tyName = do
         match (conP conName $ map varP vars)
         (normalB
          [| from $ Assoc
-              $(listE [ [| ( $(return $ LitE $ StringL $ key conName fname) :: T.Text
+              $(listE [ [| (T.pack $(return $ LitE $ StringL $ key conName fname) :: T.Text
                            , toObject $(varE v)) |]
                       | (v, (fname, _, _)) <- zip vars elms])
           |])
@@ -93,7 +93,7 @@ deriveUnpack asObject tyName = do
 
     binds conName var res (fname, _, _) =
       bindS (varP res)
-            [| failN $ lookup ($(return $ LitE $ StringL $ key conName fname) :: T.Text)
+            [| failN $ lookup (T.pack $(return $ LitE $ StringL $ key conName fname) :: T.Text)
                               $(varE var) |]
 
 deriveObject :: Bool -> Name -> Q [Dec]


### PR DESCRIPTION
This fixes two bugs in Derive.hs.

The first bug prevented compilation and was fixed by adding T.pack to convert String to Text.

The second bug relates to issue #38 and caused ADTs to be serialised improperly. Constructor alternatives were only distinguished by their field types, which led to problems if different constructors had the same field types. The fix is to include the constructor name in the serialised value.
