### PR TITLE
Update text version

### DIFF
--- a/msgpack-rpc/Network/MessagePackRpc/Client.hs
+++ b/msgpack-rpc/Network/MessagePackRpc/Client.hs
@@ -32,6 +32,7 @@ module Network.MessagePackRpc.Client (
   -- * MessagePack Client type
   ClientT, Client,
   runClient,
+  runClientResult,
 
   -- * Call RPC method
   call,
@@ -76,6 +77,14 @@ runClient host port m = do
   runTCPClient (clientSettings port host) $ \ad -> do
     (rsrc, _) <- appSource ad $$+ return ()
     void $ evalStateT (unClientT m) (Connection rsrc (appSink ad) 0)
+
+runClientResult :: (MonadIO m, MonadBaseControl IO m)
+             => S.ByteString -> Int -> ClientT m a -> m a
+runClientResult host port m = do
+  runTCPClient (clientSettings port host) $ \ad -> do
+    (rsrc, _) <- appSource ad $$+ return ()
+    evalStateT (unClientT m) (Connection rsrc (appSink ad) 0)
+
 
 -- | RPC error type
 data RpcError

--- a/msgpack-rpc/msgpack-rpc.cabal
+++ b/msgpack-rpc/msgpack-rpc.cabal
@@ -20,7 +20,7 @@ source-repository head
 library
   build-depends:     base               >= 4.5 && < 4.7
                    , bytestring         >= 0.9
-                   , text               == 0.11.*
+                   , text               >= 0.11.0
                    , network            >= 2.2 && < 2.5
                    , random             == 1.0.*
                    , mtl                >= 2.1

--- a/msgpack-rpc/msgpack-rpc.cabal
+++ b/msgpack-rpc/msgpack-rpc.cabal
@@ -25,9 +25,10 @@ library
                    , random             == 1.0.*
                    , mtl                >= 2.1
                    , monad-control      >= 0.3
-                   , conduit            >= 0.5
-                   , network-conduit    >= 0.6
-                   , attoparsec-conduit >= 0.5
+                   , conduit            == 1.0.17.1
+                   , network-conduit    == 1.0.4
+                   , attoparsec-conduit == 1.0.1.2
+                   , attoparsec
                    , msgpack            == 0.7.*
 
   exposed-modules:   Network.MessagePackRpc.Server

--- a/msgpack/msgpack.cabal
+++ b/msgpack/msgpack.cabal
@@ -27,7 +27,7 @@ Library
                   , unordered-containers >= 0.1 && < 0.3
                   , hashable
                   , vector        >= 0.7 && < 0.11
-                  , attoparsec    >= 0.8 && < 0.11
+                  , attoparsec    >= 0.11.2.1
                   , blaze-builder >= 0.3 && < 0.4
                   , deepseq       >= 1.1 && < 1.4
                   , template-haskell >= 2.4 && < 2.9

--- a/msgpack/msgpack.cabal
+++ b/msgpack/msgpack.cabal
@@ -22,7 +22,7 @@ Library
                   , ghc-prim      >= 0.2
                   , mtl           >= 2.0
                   , bytestring    == 0.10.*
-                  , text          == 0.11.*
+                  , text          >= 0.11.0
                   , containers    >= 0.4
                   , unordered-containers >= 0.1 && < 0.3
                   , hashable


### PR DESCRIPTION
msgpack and msgpack-rpc currently require text == 0.11.*
safecopy-0.8.2 requries text-1.1.0.0

So msgpack and msgpack-rpc are currently incompatible with safecopy.

This change makes them compatible again.
