### PR TITLE
Fix MessagePack Maybe instance, add Maybe tests, fix msgpack-rpc tests, fix documentation

### DIFF
--- a/msgpack-rpc/src/Network/MessagePack/Client.hs
+++ b/msgpack-rpc/src/Network/MessagePack/Client.hs
@@ -39,7 +39,6 @@ module Network.MessagePack.Client (
   RpcError(..),
   ) where
 
-import           Control.Applicative
 import           Control.Exception
 import           Control.Monad
 import           Control.Monad.Catch
@@ -52,7 +51,6 @@ import           Data.Conduit.Network
 import           Data.Conduit.Serialization.Binary
 import           Data.MessagePack
 import           Data.Typeable
-import           System.IO
 
 newtype Client a
   = ClientT { runClient :: StateT Connection IO a }

--- a/msgpack-rpc/src/Network/MessagePack/Client.hs
+++ b/msgpack-rpc/src/Network/MessagePack/Client.hs
@@ -81,12 +81,15 @@ instance Exception RpcError
 class RpcType r where
   rpcc :: String -> [Object] -> r
 
-instance MessagePack o => RpcType (Client o) where
-  rpcc m args = do
-    res <- rpcCall m (reverse args)
-    case fromObject res of
-      Just r  -> return r
-      Nothing -> throwM $ ResultTypeError "type mismatch"
+instance MessagePack o =>
+         RpcType (Client o) where
+    rpcc m args = do
+        res <- rpcCall m (reverse args)
+        case fromObject res of
+            Just r -> return r
+            Nothing ->
+                throwM $
+                ResultTypeError ("type mismatch, object: " ++ show res)
 
 instance (MessagePack o, RpcType r) => RpcType (o -> r) where
   rpcc m args arg = rpcc m (toObject arg:args)

--- a/msgpack-rpc/src/Network/MessagePack/Client.hs
+++ b/msgpack-rpc/src/Network/MessagePack/Client.hs
@@ -22,7 +22,7 @@
 -- > add :: Int -> Int -> Client Int
 -- > add = call "add"
 -- >
--- > main = runClient "localhost" 5000 $ do
+-- > main = execClient "localhost" 5000 $ do
 -- >   ret <- add 123 456
 -- >   liftIO $ print ret
 --

--- a/msgpack-rpc/src/Network/MessagePack/Server.hs
+++ b/msgpack-rpc/src/Network/MessagePack/Server.hs
@@ -41,7 +41,6 @@ module Network.MessagePack.Server (
   serve,
   ) where
 
-import           Control.Applicative
 import           Control.Monad
 import           Control.Monad.Catch
 import           Control.Monad.Trans
@@ -92,6 +91,7 @@ instance (MonadThrow m, MessagePack o, MethodType m r) => MethodType m (o -> r) 
     case fromObject x of
       Nothing -> throwM $ ServerError "argument type error"
       Just r  -> toBody (f r) xs
+  toBody _ [] = error "messagepack-rpc methodtype instance toBody failed"
 
 -- | Build a method
 method :: MethodType m f

--- a/msgpack-rpc/test/test.hs
+++ b/msgpack-rpc/test/test.hs
@@ -32,7 +32,7 @@ server =
     echo s = return $ "***" ++ s ++ "***"
 
 client :: IO ()
-client = execClient "localhost" port $ do
+client = execClient "127.0.0.1" port $ do
   r1 <- add 123 456
   liftIO $ r1 @?= 123 + 456
   r2 <- echo "hello"

--- a/msgpack/msgpack.cabal
+++ b/msgpack/msgpack.cabal
@@ -33,7 +33,7 @@ library
                   , text                 >=1.2
                   , containers           >=0.5.5
                   , unordered-containers >=0.2.5
-                  , hashable
+                  , hashable             >=1.2.4.0
                   , vector               >=0.10
                   , blaze-builder        >=0.4
                   , deepseq              >=1.3

--- a/msgpack/src/Data/MessagePack/Get.hs
+++ b/msgpack/src/Data/MessagePack/Get.hs
@@ -22,7 +22,8 @@ module Data.MessagePack.Get(
 import           Control.Applicative
 import           Control.Monad
 import           Data.Binary
-import           Data.Binary.Get
+import           Data.Binary.Get (getByteString, getWord16be,
+                                  getWord32be, getWord64be)
 import           Data.Binary.IEEE754
 import           Data.Bits
 import qualified Data.ByteString     as S

--- a/msgpack/src/Data/MessagePack/Object.hs
+++ b/msgpack/src/Data/MessagePack/Object.hs
@@ -191,9 +191,8 @@ instance MessagePack a => MessagePack (Maybe a) where
     Nothing -> ObjectNil
 
   fromObject = \case
-    ObjectNil     -> Just Nothing
-    ObjectExt _ _ -> Nothing
-    obj           -> Just $ fromObject obj
+    ObjectNil -> Just Nothing
+    obj       -> Just <$> fromObject obj
 
 -- UTF8 string like
 

--- a/msgpack/src/Data/MessagePack/Object.hs
+++ b/msgpack/src/Data/MessagePack/Object.hs
@@ -188,8 +188,9 @@ instance MessagePack a => MessagePack (Maybe a) where
     Nothing -> ObjectNil
 
   fromObject = \case
-    ObjectNil -> Just Nothing
-    obj -> fromObject obj
+    ObjectNil     -> Just Nothing
+    ObjectExt _ _ -> Nothing
+    obj           -> Just $ fromObject obj
 
 -- UTF8 string like
 

--- a/msgpack/src/Data/MessagePack/Object.hs
+++ b/msgpack/src/Data/MessagePack/Object.hs
@@ -194,6 +194,15 @@ instance MessagePack a => MessagePack (Maybe a) where
                                    v V.!? 0
   fromObject _               = Just Nothing
 
+instance (MessagePack a, MessagePack b) => MessagePack (Either a b) where
+  toObject = \case
+    Left a  -> toObject (False, toObject a)
+    Right b -> toObject (True,  toObject b)
+
+  fromObject e = do
+    (b, o) <- fromObject e
+    if b then Right <$> fromObject o else Left <$> fromObject o 
+
 -- UTF8 string like
 
 instance MessagePack L.ByteString where

--- a/msgpack/src/Data/MessagePack/Object.hs
+++ b/msgpack/src/Data/MessagePack/Object.hs
@@ -1,8 +1,13 @@
+{-# LANGUAGE DefaultSignatures    #-}
 {-# LANGUAGE DeriveDataTypeable   #-}
+{-# LANGUAGE EmptyCase            #-}
+{-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE IncoherentInstances  #-}
 {-# LANGUAGE LambdaCase           #-}
 {-# LANGUAGE OverloadedLists      #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 
 --------------------------------------------------------------------
@@ -30,6 +35,7 @@ module Data.MessagePack.Object(
 import           Control.Applicative
 import           Control.Arrow
 import           Control.DeepSeq
+import           Control.Monad
 import           Data.Binary
 import qualified Data.ByteString        as S
 import qualified Data.ByteString.Lazy   as L
@@ -41,12 +47,16 @@ import qualified Data.Text              as T
 import qualified Data.Text.Lazy         as LT
 import           Data.Typeable
 import qualified Data.Vector            as V
+import           Data.Void
+import           GHC.Generics       hiding (from, to)
+import qualified GHC.Generics           as G (from, to)
 
 import           Data.MessagePack.Assoc
 import           Data.MessagePack.Get
 import           Data.MessagePack.Put
 
 import           Prelude                hiding (putStr)
+
 
 -- | Object Representation of MessagePack data.
 data Object
@@ -111,7 +121,16 @@ instance Binary Object where
 
 class MessagePack a where
   toObject   :: a -> Object
+  default toObject
+    :: (Generic a, GenericMessagePack (Rep a))
+    => a -> Object
+  toObject = genericToObject . G.from
+
   fromObject :: Object -> Maybe a
+  default fromObject
+    :: (Generic a, GenericMessagePack (Rep a))
+    => Object -> Maybe a
+  fromObject = fmap G.to . genericFromObject
 
 -- core instances
 
@@ -183,25 +202,11 @@ instance (MessagePack a, MessagePack b) => MessagePack (Assoc (V.Vector (a, b)))
 
 -- util instances
 
--- nullable
+instance MessagePack Void
 
-instance MessagePack a => MessagePack (Maybe a) where
-  toObject = \case
-    Just a  -> ObjectArray $ V.singleton $ toObject a
-    Nothing -> ObjectArray V.empty
+instance MessagePack a => MessagePack (Maybe a)
 
-  fromObject (ObjectArray v) = maybe (Just Nothing) (Just <$> fromObject) $
-                                   v V.!? 0
-  fromObject _               = Just Nothing
-
-instance (MessagePack a, MessagePack b) => MessagePack (Either a b) where
-  toObject = \case
-    Left a  -> toObject (False, toObject a)
-    Right b -> toObject (True,  toObject b)
-
-  fromObject e = do
-    (b, o) <- fromObject e
-    if b then Right <$> fromObject o else Left <$> fromObject o 
+instance (MessagePack a, MessagePack b) => MessagePack (Either a b)
 
 -- UTF8 string like
 
@@ -243,7 +248,7 @@ instance (MessagePack k, MessagePack v, Hashable k, Eq k) => MessagePack (HashMa
   toObject = toObject . Assoc . HashMap.toList
   fromObject obj = HashMap.fromList . unAssoc <$> fromObject obj
 
--- tuples
+-- tuples (manual definition uses slightly less bytes to serialize)
 
 instance (MessagePack a1, MessagePack a2) => MessagePack (a1, a2) where
   toObject (a1, a2) = ObjectArray [toObject a1, toObject a2]
@@ -284,3 +289,45 @@ instance (MessagePack a1, MessagePack a2, MessagePack a3, MessagePack a4, Messag
   toObject (a1, a2, a3, a4, a5, a6, a7, a8, a9) = ObjectArray [toObject a1, toObject a2, toObject a3, toObject a4, toObject a5, toObject a6, toObject a7, toObject a8, toObject a9]
   fromObject (ObjectArray [a1, a2, a3, a4, a5, a6, a7, a8, a9]) = (,,,,,,,,) <$> fromObject a1 <*> fromObject a2 <*> fromObject a3 <*> fromObject a4 <*> fromObject a5 <*> fromObject a6 <*> fromObject a7 <*> fromObject a8 <*> fromObject a9
   fromObject _ = Nothing
+
+-- generics
+
+class GenericMessagePack f where
+  genericToObject :: f a -> Object
+  genericFromObject :: Object -> Maybe (f a)
+
+instance GenericMessagePack V1 where
+  genericToObject = \case {}
+  genericFromObject _ = Nothing
+
+instance GenericMessagePack U1 where
+  genericToObject U1 = ObjectNil
+  genericFromObject ObjectNil = Just U1
+  genericFromObject _         = Nothing
+
+instance GenericMessagePack a => GenericMessagePack (M1 i c a) where
+  genericToObject (M1 x) = genericToObject x
+  genericFromObject o = M1 <$> genericFromObject o
+
+instance MessagePack a => GenericMessagePack (K1 i a) where
+  genericToObject (K1 x) = toObject x
+  genericFromObject o = K1 <$> fromObject o
+
+-- TODO: next 2 instances could be optimized
+instance (GenericMessagePack a, GenericMessagePack b)
+       => GenericMessagePack (a :+: b) where
+  genericToObject (L1 x) = toObject (False, genericToObject x)
+  genericToObject (R1 x) = toObject (True , genericToObject x)
+  genericFromObject o = case fromObject o of
+    Just (False, o') -> L1 <$> genericFromObject o'
+    Just (True , o') -> R1 <$> genericFromObject o'
+    _                -> Nothing
+
+instance (GenericMessagePack a, GenericMessagePack b)
+       => GenericMessagePack (a :*: b) where
+  genericToObject (a :*: b) = toObject (genericToObject a, genericToObject b)
+  genericFromObject o = case fromObject o of
+    Just (a, b) -> liftM2 (:*:) (genericFromObject a) (genericFromObject b)
+    _           -> Nothing
+
+

--- a/msgpack/src/Data/MessagePack/Object.hs
+++ b/msgpack/src/Data/MessagePack/Object.hs
@@ -120,10 +120,13 @@ instance MessagePack Object where
   fromObject = Just
 
 instance MessagePack () where
-  toObject _ = ObjectNil
+  toObject _ = ObjectArray V.empty
   fromObject = \case
-    ObjectNil -> Just ()
-    _         -> Nothing
+    ObjectArray v ->
+        if V.null v
+            then Just ()
+            else Nothing
+    _ -> Nothing
 
 instance MessagePack Int where
   toObject = ObjectInt

--- a/msgpack/src/Data/MessagePack/Object.hs
+++ b/msgpack/src/Data/MessagePack/Object.hs
@@ -187,12 +187,12 @@ instance (MessagePack a, MessagePack b) => MessagePack (Assoc (V.Vector (a, b)))
 
 instance MessagePack a => MessagePack (Maybe a) where
   toObject = \case
-    Just a  -> toObject a
-    Nothing -> ObjectNil
+    Just a  -> ObjectArray $ V.singleton $ toObject a
+    Nothing -> ObjectArray V.empty
 
-  fromObject = \case
-    ObjectNil -> Just Nothing
-    obj       -> Just <$> fromObject obj
+  fromObject (ObjectArray v) = maybe (Just Nothing) (Just <$> fromObject) $
+                                   v V.!? 0
+  fromObject _               = Just Nothing
 
 -- UTF8 string like
 

--- a/msgpack/test/test.hs
+++ b/msgpack/test/test.hs
@@ -66,17 +66,8 @@ tests =
       \(a :: Maybe Int) -> a == mid a
     , testProperty "maybe nil" $
       \(a :: Maybe ()) -> a == mid a
-
-   -- FIXME: this test is also failing
-   --
-   -- it should probably be decoded somewhat specially with ObjectExt ?
-   --
-   -- , testProperty "maybe maybe int" $
-   --   \(a :: Maybe (Maybe Int)) -> a == mid a
-   --
-   -- by looking at msgpack specification it looks like Haskells Maybe
-   -- type should be probably decoded with custom ObjectExt
-   --
+    , testProperty "maybe maybe int" $
+      \(a :: Maybe (Maybe Int)) -> a == mid a
     , testProperty "maybe bool" $
       \(a :: Maybe Bool) -> a == mid a
     , testProperty "maybe double" $

--- a/msgpack/test/test.hs
+++ b/msgpack/test/test.hs
@@ -96,4 +96,13 @@ tests =
       \(a :: Maybe [(String, String)]) -> a == mid a
     , testProperty "maybe (Assoc [(string, int)])" $
       \(a :: Maybe (Assoc [(String, Int)])) -> a == mid a
+    -- either tests
+    , testProperty "either () ()" $
+      \(a :: Either () ()) -> a == mid a
+    , testProperty "either int int" $
+      \(a :: Either Int Int) -> a == mid a
+    , testProperty "either int double" $
+      \(a :: Either Int Double) -> a == mid a
+    , testProperty "either [string] string" $
+      \(a :: Either [String] String) -> a == mid a
     ]

--- a/msgpack/test/test.hs
+++ b/msgpack/test/test.hs
@@ -75,6 +75,13 @@ tests =
    --
    -- , testProperty "maybe nil" $
    --   \(a :: Maybe ()) -> a == mid a
+
+   -- FIXME: this test is also failing
+   --
+   -- it should probably be decoded somewhat specially with Put/Get ?
+   --
+   -- , testProperty "maybe maybe int" $
+   --   \(a :: Maybe (Maybe Int)) -> a == mid a
     , testProperty "maybe bool" $
       \(a :: Maybe Bool) -> a == mid a
     , testProperty "maybe double" $

--- a/msgpack/test/test.hs
+++ b/msgpack/test/test.hs
@@ -61,4 +61,46 @@ tests =
       \(a :: [(String, String)]) -> a == mid a
     , testProperty "Assoc [(string, int)]" $
       \(a :: Assoc [(String, Int)]) -> a == mid a
+      -- maybe tests
+    , testProperty "maybe int" $
+      \(a :: Maybe Int) -> a == mid a
+   -- FIXME: this test is failing:
+   --
+   -- toObject () == ObjectNil
+   -- toObject (Just ()) == ObjectNil
+   -- toObject (Just $ Just ()) == ObjectNil
+   --
+   -- I am not sure how should these types be decoded?
+   -- One way is to add additional ObjectEmpty for decoding ()
+   --
+   -- , testProperty "maybe nil" $
+   --   \(a :: Maybe ()) -> a == mid a
+    , testProperty "maybe bool" $
+      \(a :: Maybe Bool) -> a == mid a
+    , testProperty "maybe double" $
+      \(a :: Maybe Double) -> a == mid a
+    , testProperty "maybe string" $
+      \(a :: Maybe String) -> a == mid a
+    , testProperty "maybe bytestring" $
+      \(a :: Maybe S.ByteString) -> a == mid a
+    , testProperty "maybe lazy-bytestring" $
+      \(a :: Maybe L.ByteString) -> a == mid a
+    , testProperty "maybe [int]" $
+      \(a :: Maybe [Int]) -> a == mid a
+    , testProperty "maybe [string]" $
+      \(a :: Maybe [String]) -> a == mid a
+    , testProperty "maybe (int, int)" $
+      \(a :: Maybe (Int, Int)) -> a == mid a
+    , testProperty "maybe (int, int, int)" $
+      \(a :: Maybe (Int, Int, Int)) -> a == mid a
+    , testProperty "maybe (int, int, int, int)" $
+      \(a :: Maybe (Int, Int, Int, Int)) -> a == mid a
+    , testProperty "maybe (int, int, int, int, int)" $
+      \(a :: Maybe (Int, Int, Int, Int, Int)) -> a == mid a
+    , testProperty "maybe [(int, double)]" $
+      \(a :: Maybe [(Int, Double)]) -> a == mid a
+    , testProperty "maybe [(string, string)]" $
+      \(a :: Maybe [(String, String)]) -> a == mid a
+    , testProperty "maybe (Assoc [(string, int)])" $
+      \(a :: Maybe (Assoc [(String, Int)])) -> a == mid a
     ]

--- a/msgpack/test/test.hs
+++ b/msgpack/test/test.hs
@@ -71,17 +71,20 @@ tests =
    -- toObject (Just $ Just ()) == ObjectNil
    --
    -- I am not sure how should these types be decoded?
-   -- One way is to add additional ObjectEmpty for decoding ()
    --
    -- , testProperty "maybe nil" $
    --   \(a :: Maybe ()) -> a == mid a
 
    -- FIXME: this test is also failing
    --
-   -- it should probably be decoded somewhat specially with Put/Get ?
+   -- it should probably be decoded somewhat specially with ObjectExt ?
    --
    -- , testProperty "maybe maybe int" $
    --   \(a :: Maybe (Maybe Int)) -> a == mid a
+   --
+   -- by looking at msgpack specification it looks like Haskells Maybe
+   -- type should be probably decoded with custom ObjectExt
+   --
     , testProperty "maybe bool" $
       \(a :: Maybe Bool) -> a == mid a
     , testProperty "maybe double" $

--- a/msgpack/test/test.hs
+++ b/msgpack/test/test.hs
@@ -7,6 +7,7 @@ import qualified Data.ByteString.Char8      as S
 import qualified Data.ByteString.Lazy.Char8 as L
 import           Data.Maybe
 import           Data.MessagePack
+import           Data.Void
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
@@ -106,3 +107,7 @@ tests =
     , testProperty "either [string] string" $
       \(a :: Either [String] String) -> a == mid a
     ]
+
+-- type-check test
+checkVoid :: Void -> Object
+checkVoid = toObject

--- a/msgpack/test/test.hs
+++ b/msgpack/test/test.hs
@@ -64,16 +64,8 @@ tests =
       -- maybe tests
     , testProperty "maybe int" $
       \(a :: Maybe Int) -> a == mid a
-   -- FIXME: this test is failing:
-   --
-   -- toObject () == ObjectNil
-   -- toObject (Just ()) == ObjectNil
-   -- toObject (Just $ Just ()) == ObjectNil
-   --
-   -- I am not sure how should these types be decoded?
-   --
-   -- , testProperty "maybe nil" $
-   --   \(a :: Maybe ()) -> a == mid a
+    , testProperty "maybe nil" $
+      \(a :: Maybe ()) -> a == mid a
 
    -- FIXME: this test is also failing
    --

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,10 +1,13 @@
+resolver: lts-6.1
 flags: {}
+extra-deps:
+- peggy-0.3.2
 packages:
 - msgpack/
 - msgpack-rpc/
 - msgpack-aeson/
+nix:
+    enable: false
+    packages: [zlib]
 # - msgpack-idl/
 # - msgpack-idl-web/
-extra-deps:
-- peggy-0.3.2
-resolver: lts-2.15


### PR DESCRIPTION
Previous `MessagePack Maybe` instance was hanging. This patch should fix that. Tests for `MessagePack` were updated with `Maybe` tests.

Besides that, `Maybe ()` was ambiguous with `Maybe Nothing` (`Nothing` was encoded as `()` was, with `ObjectNil`). To resolve it we have encoded `()` as empty vector. Using `Maybe ()` doesn't make much sense, but here is the fix anyway.

On some machines, when using `localhost` as host for `execClient`, exception "Exception: connect: does not exist (Connection refused)" is thrown. I am not sure is this underlying OS problem, but as tests are run on the same machine it makes sense to change this to `127.0.0.1`. This doesn't throw an exception.

Fix documentation `runClient` -> `execClient`.
