### PR TITLE
Fix decoding of `Maybe a`.

### DIFF
--- a/msgpack/src/Data/MessagePack/Object.hs
+++ b/msgpack/src/Data/MessagePack/Object.hs
@@ -189,7 +189,7 @@ instance MessagePack a => MessagePack (Maybe a) where
 
   fromObject = \case
     ObjectNil -> Just Nothing
-    obj -> fromObject obj
+    obj -> Just <$> fromObject obj
 
 -- UTF8 string like
 


### PR DESCRIPTION
It used to cause an infinite recursive call to `Maybe a`'s `fromObject`. This is
fixed now.

Fixes #69