### PR TITLE
Minor changes

### DIFF
--- a/msgpack/src/Data/MessagePack/Generic.hs
+++ b/msgpack/src/Data/MessagePack/Generic.hs
@@ -5,11 +5,13 @@
 {-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Data.MessagePack.Generic
     ( GMessagePack
     , genericToObject
     , genericFromObject
+    , GenericMsgPack(..)
     ) where
 
 import           Compat.Prelude
@@ -23,6 +25,12 @@ genericToObject = gToObject . from
 
 genericFromObject :: (Generic a, GMessagePack (Rep a)) => Object -> Result a
 genericFromObject x = to <$> gFromObject x
+
+newtype GenericMsgPack a = GenericMsgPack a
+
+instance (Generic a, GMessagePack (Rep a)) => MessagePack (GenericMsgPack a) where
+  toObject (GenericMsgPack a) = genericToObject a
+  fromObject a = GenericMsgPack <$> genericFromObject a
 
 class GMessagePack f where
   gToObject   :: f a -> Object

--- a/msgpack/src/Data/MessagePack/Generic.hs
+++ b/msgpack/src/Data/MessagePack/Generic.hs
@@ -110,12 +110,12 @@ instance (GSumPack a, GSumPack b) => GSumPack (a :+: b) where
       sizeR = size - sizeL
 
 
-instance GSumPack (C1 c U1) where
+instance {-# OVERLAPPING #-} GSumPack (C1 c U1) where
   sumToObject code _ _ = toObject code
   sumFromObject _ _ = gFromObject
 
 
-instance GMessagePack a => GSumPack (C1 c a) where
+instance {-# OVERLAPPABLE #-} GMessagePack a => GSumPack (C1 c a) where
   sumToObject code _ x = toObject (code, gToObject x)
   sumFromObject _ _ = gFromObject
 

--- a/msgpack/src/Data/MessagePack/Object.hs
+++ b/msgpack/src/Data/MessagePack/Object.hs
@@ -21,6 +21,10 @@ module Data.MessagePack.Object (
   -- * MessagePack Object
   Object(..),
 
+  withNil, withBool, withInt,
+  withFloat, withDouble, withBin, withStr,
+  withArray, withMap,
+
   -- * MessagePack Serializable Types
   MessagePack(..), typeMismatch, Result(..)
   ) where

--- a/msgpack/test/DataCases.hs
+++ b/msgpack/test/DataCases.hs
@@ -74,7 +74,7 @@ data DataCase = DataCase
   } deriving Show
 
 instance FromYAML DataCase where
-  parseYAML = withMap "DataCase" $ \m -> do
+  parseYAML = Y.withMap "DataCase" $ \m -> do
     msgpack <- m .: "msgpack"
 
     obj <- do { Just (Y.Scalar Y.SNull) <- m .:! "nil" ; pure ObjectNil }


### PR DESCRIPTION
The following changes are done:

1) Add proper overlap pragmas so that GHC doesn't choke up on instance resolution during generic deriving for certain data types.

2) Export some useful helpers when writing `MessagePack` instances by hand.

3) Export a useful newtype `GenericMsgPack` which will work well with `DerivingVia` to avoid the boilerplate when using generic deriving.