### PR TITLE
msgpack-rpc is compatible with base-7.13

### DIFF
--- a/msgpack-rpc/msgpack-rpc.cabal
+++ b/msgpack-rpc/msgpack-rpc.cabal
@@ -26,7 +26,7 @@ library
   exposed-modules:  Network.MessagePack.Server
                     Network.MessagePack.Client
 
-  build-depends:    base               >= 4.5     && < 4.13
+  build-depends:    base               >= 4.5     && < 4.14
                   , bytestring         >= 0.10.4  && < 0.11
                   , text               >= 1.2.3   && < 1.3
                   , network            >= 2.6     && < 2.9


### PR DESCRIPTION
I was able to build it successfully without any change.