### PR TITLE
fix(msgpack-aeson)!: support aeson version 2

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -6,3 +6,8 @@ packages:
     msgpack-rpc
 --  msgpack-idl
 --  msgpack-idl-web
+
+source-repository-package
+    type: git
+    location: https://github.com/input-output-hk/int-cast
+    tag: 20cc3a9

--- a/msgpack-aeson/msgpack-aeson.cabal
+++ b/msgpack-aeson/msgpack-aeson.cabal
@@ -23,11 +23,10 @@ library
   hs-source-dirs:      src
   exposed-modules:     Data.MessagePack.Aeson
 
-  build-depends:       base                   >= 4.7     && < 4.14
-                     , aeson                  >= 0.8.0.2 && < 0.12
-                                           || >= 1.0     && < 1.5
-                     , bytestring             >= 0.10.4  && < 0.11
-                     , msgpack                >= 1.1.0   && < 1.2
+  build-depends:       base                   >= 4.7     && < 4.18
+                     , aeson                  >= 2.0.0.0 && < 2.2.0.0
+                     , bytestring             >= 0.10.4  && < 0.12
+                     , msgpack                >= 1.0.0   && < 1.2
                      , scientific             >= 0.3.2   && < 0.4
                      , text                   >= 1.2.3   && < 1.3
                      , unordered-containers   >= 0.2.5   && < 0.3

--- a/msgpack-rpc/msgpack-rpc.cabal
+++ b/msgpack-rpc/msgpack-rpc.cabal
@@ -26,16 +26,15 @@ library
   exposed-modules:  Network.MessagePack.Server
                     Network.MessagePack.Client
 
-  build-depends:    base               >= 4.5     && < 4.13
-                  , bytestring         >= 0.10.4  && < 0.11
+  build-depends:    base               >= 4.5     && < 4.18
+                  , bytestring         >= 0.10.4  && < 0.12
                   , text               >= 1.2.3   && < 1.3
-                  , network            >= 2.6     && < 2.9
-                                    || >= 3.0     && < 3.1
+                  , network            >= 3.0     && < 3.2
                   , mtl                >= 2.2.1   && < 2.3
                   , monad-control      >= 1.0.0.0 && < 1.1
-                  , conduit            >= 1.2.3.1 && < 1.3
-                  , conduit-extra      >= 1.1.3.4 && < 1.3
-                  , binary-conduit     >= 1.2.3   && < 1.3
+                  , conduit            >= 1.2.3.1 && < 1.4
+                  , conduit-extra      >= 1.1.3.4 && < 1.4
+                  , binary-conduit     >= 1.2.3   && < 1.4
                   , exceptions         >= 0.8     && < 0.11
                   , binary             >= 0.7.1   && < 0.9
                   , msgpack            >= 1.1.0   && < 1.2

--- a/msgpack/msgpack.cabal
+++ b/msgpack/msgpack.cabal
@@ -71,9 +71,9 @@ library
                     Compat.Binary
                     Compat.Prelude
 
-  build-depends:    base                 >= 4.7     && < 4.14
+  build-depends:    base                 >= 4.7     && < 4.17
                   , mtl                  >= 2.2.1   && < 2.3
-                  , bytestring           >= 0.10.4  && < 0.11
+                  , bytestring           >= 0.10.4  && < 0.12
                   , text                 >= 1.2.3   && < 1.3
                   , containers           >= 0.5.5   && < 0.7
                   , unordered-containers >= 0.2.5   && < 0.3
@@ -117,8 +117,8 @@ test-suite msgpack-tests
                   -- test-specific dependencies
                   , async              == 2.2.*
                   , filepath           == 1.3.* || == 1.4.*
-                  , HsYAML             >= 0.1.1 && < 0.2
+                  , HsYAML             == 0.2.*
                   , tasty              == 1.2.*
                   , tasty-quickcheck   == 0.10.*
                   , tasty-hunit        == 0.10.*
-                  , QuickCheck         == 2.13.*
+                  , QuickCheck         == 2.14.*


### PR DESCRIPTION
I have written a simple code to support version 2 of aeson and have only verified that it compiles and passes, but have not yet tested it to work.